### PR TITLE
feat: Make incremental updates to inventory file

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -73,7 +73,7 @@ var createCmd = &cobra.Command{
 		fmt.Println("Creating resources for EKS cluster...")
 		err = resourceClient.CreateResourceStack(inventoryFile, resourceConfig)
 		if err != nil {
-			fmt.Println("Problem encountered creating resources - deleting resources that were created")
+			fmt.Println("Problem encountered creating resources - deleting resources that were created: %w", err)
 			if deleteErr := resourceClient.DeleteResourceStack(inventoryFile); deleteErr != nil {
 				return fmt.Errorf("\nError creating resources: %w\nError deleting resources: %s", err, deleteErr)
 			}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -5,9 +5,11 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -16,8 +18,7 @@ import (
 )
 
 var (
-	inventoryFileOut string
-	configFile       string
+	configFile string
 )
 
 // createCmd represents the create command
@@ -49,24 +50,37 @@ var createCmd = &cobra.Command{
 		ctx := context.Background()
 		resourceClient := resource.ResourceClient{&msgChan, ctx, awsConfig}
 
+		// Create a channel to receive OS signals
+		sigs := make(chan os.Signal, 1)
+
+		// Register the channel to receive SIGINT signals
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+		// Run a goroutine to handle the signal. It will block until it receives a signal
+		go func() {
+			<-sigs
+			fmt.Println("\nReceived Ctrl+C, cleaning up resources...")
+			if err = resourceClient.DeleteResourceStack(inventoryFile); err != nil {
+				fmt.Errorf("\nError deleting resources: %s", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		}()
+
+		fmt.Println("Running... Press Ctrl+C to exit")
+
 		// create resources
 		fmt.Println("Creating resources for EKS cluster...")
-		inventory, err := resourceClient.CreateResourceStack(resourceConfig)
+		err = resourceClient.CreateResourceStack(inventoryFile, resourceConfig)
 		if err != nil {
 			fmt.Println("Problem encountered creating resources - deleting resources that were created")
-			if deleteErr := resourceClient.DeleteResourceStack(inventory); deleteErr != nil {
+			if deleteErr := resourceClient.DeleteResourceStack(inventoryFile); deleteErr != nil {
 				return fmt.Errorf("\nError creating resources: %w\nError deleting resources: %s", err, deleteErr)
 			}
 			return err
 		}
 
-		// write inventory file
-		inventoryJSON, err := json.MarshalIndent(inventory, "", "  ")
-		if err != nil {
-			return err
-		}
-		ioutil.WriteFile(inventoryFileOut, inventoryJSON, 0644)
-		fmt.Printf("Inventory file '%s' written\n", inventoryFileOut)
+		fmt.Printf("Inventory file '%s' written\n", inventoryFile)
 
 		fmt.Println("EKS cluster created")
 		return nil
@@ -78,6 +92,6 @@ func init() {
 
 	createCmd.Flags().StringVarP(&configFile, "config-file", "c", "",
 		"File to read EKS cluster config from")
-	createCmd.Flags().StringVarP(&inventoryFileOut, "inventory-file", "i",
+	createCmd.Flags().StringVarP(&inventoryFile, "inventory-file", "i",
 		"eks-cluster-inventory.json", "File to write resource inventory to")
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -13,8 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var inventoryFileIn string
-
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
@@ -23,8 +21,8 @@ var deleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// load inventory
 		var resourceInventory resource.ResourceInventory
-		if inventoryFileIn != "" {
-			inventoryJSON, err := ioutil.ReadFile(inventoryFileIn)
+		if inventoryFile != "" {
+			inventoryJSON, err := ioutil.ReadFile(inventoryFile)
 			if err != nil {
 				return err
 			}
@@ -43,7 +41,7 @@ var deleteCmd = &cobra.Command{
 
 		// delete resources
 		fmt.Println("Deleting resources for EKS cluster...")
-		if err := resourceClient.DeleteResourceStack(&resourceInventory); err != nil {
+		if err := resourceClient.DeleteResourceStack(inventoryFile); err != nil {
 			return err
 		}
 
@@ -53,7 +51,7 @@ var deleteCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		ioutil.WriteFile(inventoryFileIn, emptyInventoryJSON, 0644)
+		ioutil.WriteFile(inventoryFile, emptyInventoryJSON, 0644)
 
 		fmt.Println("EKS cluster deleted")
 		return nil
@@ -63,5 +61,5 @@ var deleteCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(deleteCmd)
 
-	deleteCmd.Flags().StringVarP(&inventoryFileIn, "inventory-file", "i", "eks-cluster-inventory.json", "File to read resource inventory from")
+	deleteCmd.Flags().StringVarP(&inventoryFile, "inventory-file", "i", "eks-cluster-inventory.json", "File to read resource inventory from")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ precedence.
 var (
 	awsConfigEnv     bool
 	awsConfigProfile string
+	inventoryFile    string
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/resource/inventory.go
+++ b/pkg/resource/inventory.go
@@ -1,5 +1,10 @@
 package resource
 
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
 // ResourceInventory contains a record of all resources created so they can be
 // referenced and cleaned up.
 type ResourceInventory struct {
@@ -33,4 +38,32 @@ type ClusterInventory struct {
 	ClusterName     string `json:"clusterName"`
 	ClusterARN      string `json:"clusterARN"`
 	OIDCProviderURL string `json:"oidcProviderURL"`
+}
+
+func WriteInventory(inventoryFile string, inventory *ResourceInventory) error {
+	// write inventory file
+	inventoryJSON, err := json.MarshalIndent(inventory, "", "  ")
+	if err != nil {
+		return err
+	}
+	ioutil.WriteFile(inventoryFile, inventoryJSON, 0644)
+
+	return nil
+}
+
+func ReadInventory(inventoryFile string) (*ResourceInventory, error) {
+	// read inventory file
+	inventoryBytes, err := ioutil.ReadFile(inventoryFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshal JSON data
+	var inventory ResourceInventory
+	err = json.Unmarshal(inventoryBytes, &inventory)
+	if err != nil {
+		return nil, err
+	}
+
+	return &inventory, nil
 }

--- a/pkg/resource/node_group.go
+++ b/pkg/resource/node_group.go
@@ -138,7 +138,9 @@ func (c *ResourceClient) WaitForNodeGroups(
 		for _, nodeGroupName := range nodeGroupNames {
 			//nodeGroupStatus, err := c.getNodeGroupStatus(clusterName, nodeGroupName)
 			nodeGroup, err := c.getNodeGroupStatus(clusterName, nodeGroupName)
-			nodeGroupHealth = *nodeGroup.Health
+			if nodeGroup != nil && nodeGroup.Health != nil {
+				nodeGroupHealth = *nodeGroup.Health
+			}
 			if err != nil {
 				if errors.Is(err, ErrResourceNotFound) && nodeGroupCondition == NodeGroupConditionDeleted {
 					// resource was not found and we're waiting for it to be

--- a/pkg/resource/node_group.go
+++ b/pkg/resource/node_group.go
@@ -15,7 +15,7 @@ const (
 	NodeGroupConditionCreated = "NodeGroupCreated"
 	NodeGroupConditionDeleted = "NodeGroupDeleted"
 	NodeGroupCheckInterval    = 15 //check cluster status every 15 seconds
-	NodeGroupCheckMaxCount    = 60 // check 60 times before giving up (15 minutes)
+	NodeGroupCheckMaxCount    = 240 // check 60 times before giving up (60 minutes)
 )
 
 // CreateNodeGroups creates a private node group for an EKS cluster.
@@ -156,6 +156,9 @@ func (c *ResourceClient) WaitForNodeGroups(
 				// so condition is met
 				continue
 			}
+			if nodeGroup.Status == types.NodegroupStatusCreateFailed {
+				return fmt.Errorf("failed to create node group %s: %w", nodeGroupName, err)
+			}
 			allConditionsMet = false
 			break
 		}
@@ -163,7 +166,7 @@ func (c *ResourceClient) WaitForNodeGroups(
 		if allConditionsMet {
 			break
 		}
-		time.Sleep(time.Second * 15)
+		time.Sleep(time.Second * NodeGroupCheckInterval)
 	}
 
 	return nil

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -97,7 +97,7 @@ func (c *ResourceClient) CreateResourceStack(inventoryFile string, resourceConfi
 		}
 	}
 	inventory.SubnetIDs = allSubnetIDs
-	errWrite := WriteInventory(inventoryFile, &inventory)
+	errWrite = WriteInventory(inventoryFile, &inventory)
 	if errWrite != nil {
 		return err
 	}


### PR DESCRIPTION
This change allows `CreateResourceStack` to be interrupted by `SIGINT` or `SIGTERM` and gracefully cleanup resources. 