### PR TITLE
feat: export API package

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,17 +4,9 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"os/signal"
-	"syscall"
-
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
-	"github.com/nukleros/eks-cluster/pkg/resource"
+	"github.com/nukleros/eks-cluster/pkg/api"
 )
 
 var (
@@ -27,62 +19,10 @@ var createCmd = &cobra.Command{
 	Short: "Provision an EKS cluster in AWS",
 	Long:  `Provision an EKS cluster in AWS.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// load config
-		resourceConfig := resource.NewResourceConfig()
-		if configFile != "" {
-			configYAML, err := ioutil.ReadFile(configFile)
-			if err != nil {
-				return err
-			}
-			if err := yaml.Unmarshal(configYAML, &resourceConfig); err != nil {
-				return err
-			}
-		}
-
-		// create resource client - region is not passed since it can be set in
-		// the config file if needed
-		awsConfig, err := resource.LoadAWSConfig(awsConfigEnv, awsConfigProfile, "")
+		err := api.Create(awsConfigEnv, awsConfigProfile, inventoryFile)
 		if err != nil {
 			return err
 		}
-		msgChan := make(chan string)
-		go outputMessages(&msgChan)
-		ctx := context.Background()
-		resourceClient := resource.ResourceClient{&msgChan, ctx, awsConfig}
-
-		// Create a channel to receive OS signals
-		sigs := make(chan os.Signal, 1)
-
-		// Register the channel to receive SIGINT signals
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-		// Run a goroutine to handle the signal. It will block until it receives a signal
-		go func() {
-			<-sigs
-			fmt.Println("\nReceived Ctrl+C, cleaning up resources...")
-			if err = resourceClient.DeleteResourceStack(inventoryFile); err != nil {
-				fmt.Errorf("\nError deleting resources: %s", err)
-				os.Exit(1)
-			}
-			os.Exit(0)
-		}()
-
-		fmt.Println("Running... Press Ctrl+C to exit")
-
-		// create resources
-		fmt.Println("Creating resources for EKS cluster...")
-		err = resourceClient.CreateResourceStack(inventoryFile, resourceConfig)
-		if err != nil {
-			fmt.Println("Problem encountered creating resources - deleting resources that were created: %w", err)
-			if deleteErr := resourceClient.DeleteResourceStack(inventoryFile); deleteErr != nil {
-				return fmt.Errorf("\nError creating resources: %w\nError deleting resources: %s", err, deleteErr)
-			}
-			return err
-		}
-
-		fmt.Printf("Inventory file '%s' written\n", inventoryFile)
-
-		fmt.Println("EKS cluster created")
 		return nil
 	},
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -4,12 +4,7 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-
-	"github.com/nukleros/eks-cluster/pkg/resource"
+	"github.com/nukleros/eks-cluster/pkg/api"
 	"github.com/spf13/cobra"
 )
 
@@ -19,41 +14,10 @@ var deleteCmd = &cobra.Command{
 	Short: "Remove an EKS cluster from AWS",
 	Long:  `Remove an EKS cluster from AWS.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// load inventory
-		var resourceInventory resource.ResourceInventory
-		if inventoryFile != "" {
-			inventoryJSON, err := ioutil.ReadFile(inventoryFile)
-			if err != nil {
-				return err
-			}
-			json.Unmarshal(inventoryJSON, &resourceInventory)
-		}
-
-		// create resource client
-		awsConfig, err := resource.LoadAWSConfig(awsConfigEnv, awsConfigProfile, "")
+		err := api.Delete(awsConfigEnv, awsConfigProfile, inventoryFile)
 		if err != nil {
 			return err
 		}
-		msgChan := make(chan string)
-		go outputMessages(&msgChan)
-		ctx := context.Background()
-		resourceClient := resource.ResourceClient{&msgChan, ctx, awsConfig}
-
-		// delete resources
-		fmt.Println("Deleting resources for EKS cluster...")
-		if err := resourceClient.DeleteResourceStack(inventoryFile); err != nil {
-			return err
-		}
-
-		// update inventory file
-		var emptyResourceInventory resource.ResourceInventory
-		emptyInventoryJSON, err := json.MarshalIndent(emptyResourceInventory, "", "  ")
-		if err != nil {
-			return err
-		}
-		ioutil.WriteFile(inventoryFile, emptyInventoryJSON, 0644)
-
-		fmt.Println("EKS cluster deleted")
 		return nil
 	},
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -14,7 +14,14 @@ var deleteCmd = &cobra.Command{
 	Short: "Remove an EKS cluster from AWS",
 	Long:  `Remove an EKS cluster from AWS.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := api.Delete(awsConfigEnv, awsConfigProfile, inventoryFile)
+
+		// Create resource client
+		resourceClient, err := api.CreateResourceClient(awsConfigEnv, awsConfigProfile)
+		if err != nil {
+			return err
+		}
+
+		err = api.Delete(resourceClient, inventoryFile)
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -57,13 +56,4 @@ func init() {
 		"The AWS config profile to draw credentials from when provisioning resources")
 	rootCmd.PersistentFlags().BoolVarP(&awsConfigEnv, "aws-config-env", "e", false,
 		"Retrieve credentials from environment variables")
-}
-
-// outputMessages prints the output messages from the resource client to the
-// terminal for the CLI user.
-func outputMessages(msgChan *chan string) {
-	for {
-		msg := <-*msgChan
-		fmt.Println(msg)
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.19.0
 	github.com/aws/smithy-go v1.13.5
 	github.com/spf13/cobra v1.6.1
+	gopkg.in/yaml.v2 v2.2.8
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/nukleros/eks-cluster/pkg/resource"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	configFile string
+)
+
+func Create(awsConfigEnv bool, awsConfigProfile, inventoryFile string) error {
+	// load config
+	resourceConfig := resource.NewResourceConfig()
+	if configFile != "" {
+		configYAML, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			return err
+		}
+		if err := yaml.Unmarshal(configYAML, &resourceConfig); err != nil {
+			return err
+		}
+	}
+
+	// create resource client - region is not passed since it can be set in
+	// the config file if needed
+	awsConfig, err := resource.LoadAWSConfig(awsConfigEnv, awsConfigProfile, "")
+	if err != nil {
+		return err
+	}
+	msgChan := make(chan string)
+	go outputMessages(&msgChan)
+	ctx := context.Background()
+	resourceClient := resource.ResourceClient{&msgChan, ctx, awsConfig}
+
+	// Create a channel to receive OS signals
+	sigs := make(chan os.Signal, 1)
+
+	// Register the channel to receive SIGINT signals
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	// Run a goroutine to handle the signal. It will block until it receives a signal
+	go func() {
+		<-sigs
+		fmt.Println("\nReceived Ctrl+C, cleaning up resources...")
+		if err = resourceClient.DeleteResourceStack(inventoryFile); err != nil {
+			fmt.Errorf("\nError deleting resources: %s", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}()
+
+	fmt.Println("Running... Press Ctrl+C to exit")
+
+	// create resources
+	fmt.Println("Creating resources for EKS cluster...")
+	err = resourceClient.CreateResourceStack(inventoryFile, resourceConfig)
+	if err != nil {
+		fmt.Println("Problem encountered creating resources - deleting resources that were created: %w", err)
+		if deleteErr := resourceClient.DeleteResourceStack(inventoryFile); deleteErr != nil {
+			return fmt.Errorf("\nError creating resources: %w\nError deleting resources: %s", err, deleteErr)
+		}
+		return err
+	}
+
+	fmt.Printf("Inventory file '%s' written\n", inventoryFile)
+
+	fmt.Println("EKS cluster created")
+	return nil
+}
+
+func Delete(awsConfigEnv bool, awsConfigProfile, inventoryFile string) error {
+	// load inventory
+	var resourceInventory resource.ResourceInventory
+	if inventoryFile != "" {
+		inventoryJSON, err := ioutil.ReadFile(inventoryFile)
+		if err != nil {
+			return err
+		}
+		json.Unmarshal(inventoryJSON, &resourceInventory)
+	}
+
+	// create resource client
+	awsConfig, err := resource.LoadAWSConfig(awsConfigEnv, awsConfigProfile, "")
+	if err != nil {
+		return err
+	}
+	msgChan := make(chan string)
+	go outputMessages(&msgChan)
+	ctx := context.Background()
+	resourceClient := resource.ResourceClient{&msgChan, ctx, awsConfig}
+
+	// delete resources
+	fmt.Println("Deleting resources for EKS cluster...")
+	if err := resourceClient.DeleteResourceStack(inventoryFile); err != nil {
+		return err
+	}
+
+	// update inventory file
+	var emptyResourceInventory resource.ResourceInventory
+	emptyInventoryJSON, err := json.MarshalIndent(emptyResourceInventory, "", "  ")
+	if err != nil {
+		return err
+	}
+	ioutil.WriteFile(inventoryFile, emptyInventoryJSON, 0644)
+
+	fmt.Println("EKS cluster deleted")
+	return nil
+}
+
+// outputMessages prints the output messages from the resource client to the
+// terminal for the CLI user.
+func outputMessages(msgChan *chan string) {
+	for {
+		msg := <-*msgChan
+		fmt.Println(msg)
+	}
+}


### PR DESCRIPTION
This refactors `Create()` and `Delete()` into their own `pkg/api` directory to reduce duplicated code when importing `eks-cluster` elsewhere.