### PR TITLE
feat: add dns01 challenge role

### DIFF
--- a/pkg/resource/config.go
+++ b/pkg/resource/config.go
@@ -25,7 +25,9 @@ type ResourceConfig struct {
 	MinNodes                         int32                            `yaml:"minNodes"`
 	MaxNodes                         int32                            `yaml:"maxNodes"`
 	DNSManagement                    bool                             `yaml:"dnsManagement"`
+	DNS01Challenge                   bool                             `yaml:"dns01Challenge"`
 	DNSManagementServiceAccount      DNSManagementServiceAccount      `yaml:"dnsManagementServiceAccount"`
+	DNS01ChallengeServiceAccount     DNS01ChallengeServiceAccount     `yaml:"dns01ChallengeServiceAccount"`
 	StorageManagementServiceAccount  StorageManagementServiceAccount  `yaml:"storageManagementServiceAccount"`
 	ClusterAutoscaling               bool                             `yaml:"clusterAutoscaling"`
 	ClusterAutoscalingServiceAccount ClusterAutoscalingServiceAccount `yaml:"clusterAutoscalingServiceAccount"`
@@ -48,6 +50,14 @@ type AvailabilityZone struct {
 // DNSManagementServiceAccount contains the name and namespace for the
 // Kubernetes service account that needs access to manage Route53 DNS records.
 type DNSManagementServiceAccount struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+}
+
+// DNS01ChallengeServiceAccount contains the name and namespace for the
+// Kubernetes service account that needs access to perform Route53 DNS01
+// challenges.
+type DNS01ChallengeServiceAccount struct {
 	Name      string `yaml:"name"`
 	Namespace string `yaml:"namespace"`
 }

--- a/pkg/resource/inventory.go
+++ b/pkg/resource/inventory.go
@@ -19,6 +19,7 @@ type ResourceInventory struct {
 	ClusterRole            RoleInventory    `json:"clusterRole"`
 	WorkerRole             RoleInventory    `json:"workerRole"`
 	DNSManagementRole      RoleInventory    `json:"dnsManagementRole"`
+	DNS01ChallengeRole     RoleInventory    `json:"dns01ChallengeRole"`
 	StorageManagementRole  RoleInventory    `json:"storageManagementRole"`
 	ClusterAutoscalingRole RoleInventory    `json:"clusterAutoscalingRole"`
 	PolicyARNs             []string         `json:"policyARNs"`

--- a/pkg/resource/policy.go
+++ b/pkg/resource/policy.go
@@ -65,6 +65,11 @@ func (c *ResourceClient) CreateDNS01ChallengePolicy(tags *[]types.Tag, clusterNa
 
 	dnsPolicyName := fmt.Sprintf("%s-%s", DNS01ChallengePolicyName, clusterName)
 	dnsPolicyDescription := "Allow cluster services to complete DNS01 challenges"
+
+	// NOTE: As of 8/8/2023, the cert-manager documentation for the DNS01 challenge
+	// IAM policy is incorrect.  The correct policy is below, and was taken from
+	// this stack overflow post:
+	// https://github.com/cert-manager/cert-manager/issues/3079#issuecomment-657795131
 	dnsPolicyDocument := `{
 "Version": "2012-10-17",
 "Statement": [

--- a/pkg/resource/policy.go
+++ b/pkg/resource/policy.go
@@ -76,7 +76,7 @@ func (c *ResourceClient) CreateDNS01ChallengePolicy(tags *[]types.Tag, clusterNa
 {
   "Effect": "Allow",
   "Action": [
-	"route53:ChangeResourceRecordSets",
+	"route53:ChangeResourceRecordSets"
   ],
   "Resource": [
 	"arn:aws:route53:::hostedzone/*"
@@ -89,7 +89,7 @@ func (c *ResourceClient) CreateDNS01ChallengePolicy(tags *[]types.Tag, clusterNa
 	"route53:ListHostedZones",
 	"route53:ListResourceRecordSets",
 	"route53:ListHostedZonesByName"
-],
+  ],
   "Resource": [
 	"*"
   ]

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -280,10 +280,10 @@ func (c *ResourceClient) CreateResourceStack(resourceConfig *ResourceConfig) err
 			resourceConfig.AWSAccountID, oidcIssuer, &resourceConfig.DNS01ChallengeServiceAccount,
 			resourceConfig.Name)
 		if dns01ChallengeRole != nil {
-			inventory.DNSManagementRole = RoleInventory{
+			inventory.DNS01ChallengeRole = RoleInventory{
 				RoleName:       *dns01ChallengeRole.RoleName,
 				RoleARN:        *dns01ChallengeRole.Arn,
-				RolePolicyARNs: []string{*createdDNSPolicy.Arn},
+				RolePolicyARNs: []string{*createdDNS01ChallengePolicy.Arn},
 			}
 			c.sendInventory(&inventory)
 		}

--- a/pkg/resource/role.go
+++ b/pkg/resource/role.go
@@ -158,6 +158,62 @@ func (c *ResourceClient) CreateDNSManagementRole(
 	return dnsManagementRoleResp.Role, nil
 }
 
+// CreateDNS01ChallengeRole creates the IAM role needed for DNS01 challenges by
+// the Kubernetes service account of an in-cluster supporting service such as
+// cert-manager using IRSA (IAM role for service accounts).
+func (c *ResourceClient) CreateDNS01ChallengeRole(
+	tags *[]types.Tag,
+	dnsPolicyARN string,
+	awsAccountID string,
+	oidcProvider string,
+	serviceAccount *DNS01ChallengeServiceAccount,
+	clusterName string,
+) (*types.Role, error) {
+	svc := iam.NewFromConfig(*c.AWSConfig)
+
+	oidcProviderBare := strings.Trim(oidcProvider, "https://")
+	dns01ChallengeRoleName := fmt.Sprintf("%s-%s", DNSManagementRoleName, clusterName)
+	dns01ChallengeRolePolicyDocument := fmt.Sprintf(`{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::%[1]s:oidc-provider/%[2]s"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "%[2]s:sub": "system:serviceaccount:%[3]s:%[4]s",
+                    "%[2]s:aud": "sts.amazonaws.com"
+                }
+            }
+        }
+    ]
+}`, awsAccountID, oidcProviderBare, serviceAccount.Namespace, serviceAccount.Name)
+	createdDNS01ChallengeRoleInput := iam.CreateRoleInput{
+		AssumeRolePolicyDocument: &dns01ChallengeRolePolicyDocument,
+		RoleName:                 &dns01ChallengeRoleName,
+		PermissionsBoundary:      &dnsPolicyARN,
+		Tags:                     *tags,
+	}
+	dns01ChallengeRoleResp, err := svc.CreateRole(c.Context, &createdDNS01ChallengeRoleInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create role %s: %w", dns01ChallengeRoleName, err)
+	}
+
+	attachDNSManagementRolePolicyInput := iam.AttachRolePolicyInput{
+		PolicyArn: &dnsPolicyARN,
+		RoleName:  dns01ChallengeRoleResp.Role.RoleName,
+	}
+	_, err = svc.AttachRolePolicy(c.Context, &attachDNSManagementRolePolicyInput)
+	if err != nil {
+		return dns01ChallengeRoleResp.Role, fmt.Errorf("failed to attach role policy %s to %s: %w", dnsPolicyARN, dns01ChallengeRoleName, err)
+	}
+
+	return dns01ChallengeRoleResp.Role, nil
+}
+
 // CreateClusterAutoscalingRole creates the IAM role needed for cluster
 // autoscaler to manage node pool sizes using IRSA (IAM role for service
 // accounts).

--- a/pkg/resource/role.go
+++ b/pkg/resource/role.go
@@ -13,6 +13,7 @@ const (
 	ClusterRoleName            = "eks-cluster-role"
 	WorkerRoleName             = "eks-cluster-workler-role"
 	DNSManagementRoleName      = "eks-cluster-dns-management-role"
+	DNS01ChallengeRoleName     = "eks-cluster-dn01-challenge-role"
 	ClusterAutoscalingRoleName = "eks-cluster-cluster-autoscaler-role"
 	StorageManagementRoleName  = "eks-cluster-csi-driver-role"
 	ClusterPolicyARN           = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
@@ -172,7 +173,7 @@ func (c *ResourceClient) CreateDNS01ChallengeRole(
 	svc := iam.NewFromConfig(*c.AWSConfig)
 
 	oidcProviderBare := strings.Trim(oidcProvider, "https://")
-	dns01ChallengeRoleName := fmt.Sprintf("%s-%s", DNSManagementRoleName, clusterName)
+	dns01ChallengeRoleName := fmt.Sprintf("%s-%s", DNS01ChallengeRoleName, clusterName)
 	dns01ChallengeRolePolicyDocument := fmt.Sprintf(`{
     "Version": "2012-10-17",
     "Statement": [

--- a/pkg/resource/role.go
+++ b/pkg/resource/role.go
@@ -13,7 +13,7 @@ const (
 	ClusterRoleName            = "eks-cluster-role"
 	WorkerRoleName             = "eks-cluster-workler-role"
 	DNSManagementRoleName      = "eks-cluster-dns-management-role"
-	DNS01ChallengeRoleName     = "eks-cluster-dn01-challenge-role"
+	DNS01ChallengeRoleName     = "eks-cluster-dns01-challenge-role"
 	ClusterAutoscalingRoleName = "eks-cluster-cluster-autoscaler-role"
 	StorageManagementRoleName  = "eks-cluster-csi-driver-role"
 	ClusterPolicyARN           = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"

--- a/sample/eks-cluster-config.yaml
+++ b/sample/eks-cluster-config.yaml
@@ -1,5 +1,5 @@
 name: sample-cluster-0
-#region: "us-west-1"
+region: "us-east-1"
 awsAccountID: "575822346426"
 instanceTypes:
   - "t3.micro"
@@ -8,6 +8,10 @@ maxNodes: 6
 dnsManagement: true
 dnsManagementServiceAccount:
   name: external-dns
+  namespace: threeport-ingress
+dns01Challenge: true
+dns01ChallengeServiceAccount:
+  name: cert-manager
   namespace: threeport-ingress
 tags:
   tier: test


### PR DESCRIPTION
Add a role for use by support services that need to perform a DNS01 challenge (cert-manager for example).