### PR TITLE
feat: add EKS cluster security group to inventory

### DIFF
--- a/pkg/resource/inventory.go
+++ b/pkg/resource/inventory.go
@@ -26,6 +26,7 @@ type ResourceInventory struct {
 	Cluster                ClusterInventory `json:"cluster"`
 	NodeGroupNames         []string         `json:"nodeGroupNames"`
 	OIDCProviderARN        string           `json:"oidcProviderARN"`
+	SecurityGroupID        string           `json:"securityGroupID"`
 }
 
 // RoleInventory contains the details for each role created.

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -216,6 +216,17 @@ func (c *ResourceClient) CreateResourceStack(resourceConfig *ResourceConfig) err
 	}
 	c.sendMessage(fmt.Sprintf("EKS cluster ready: %s\n", *cluster.Name))
 
+	// EKS Cluster Security Group
+	securityGroupID, err := c.GetClusterSecurityGroup(resourceConfig.Name)
+	if securityGroupID != "" {
+		inventory.SecurityGroupID = securityGroupID
+		c.sendInventory(&inventory)
+	}
+	if err != nil {
+		return err
+	}
+	c.sendMessage(fmt.Sprintf("EKS cluster security group ID %s retrieved", securityGroupID))
+
 	// Node Groups
 	var nodeGroupNames []string
 	nodeGroups, err := c.CreateNodeGroups(&mapTags, *cluster.Name, resourceConfig.KubernetesVersion,

--- a/pkg/resource/security_group.go
+++ b/pkg/resource/security_group.go
@@ -1,0 +1,39 @@
+package resource
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// GetClusterSecurityGroup retrieves the security group created for the EKS
+// cluster by AWS during provisioning.
+func (c *ResourceClient) GetClusterSecurityGroup(clusterName string) (string, error) {
+	svc := ec2.NewFromConfig(*c.AWSConfig)
+
+	filterName := fmt.Sprintf("tag:aws:eks:cluster-name")
+	filters := []types.Filter{
+		{
+			Name:   &filterName,
+			Values: []string{clusterName},
+		},
+	}
+	describeSecurityGroupsInput := ec2.DescribeSecurityGroupsInput{
+		Filters: filters,
+	}
+	resp, err := svc.DescribeSecurityGroups(c.Context, &describeSecurityGroupsInput)
+	if err != nil {
+		return "", fmt.Errorf("failed to describe security groups filtered by cluster name %s", clusterName)
+	}
+
+	if len(resp.SecurityGroups) == 0 {
+		return "", errors.New(fmt.Sprintf("found zero security groups filtered by cluster name %s", clusterName))
+	}
+	if len(resp.SecurityGroups) > 1 {
+		return "", errors.New(fmt.Sprintf("found multiple security groups filtered by cluster name %s", clusterName))
+	}
+
+	return *resp.SecurityGroups[0].GroupId, nil
+}


### PR DESCRIPTION
The security group is not needed for resource clean-up since AWS creates and deletes it on behalf of the user when creating/deleting EKS clusters, however it is useful to other systems in creating other security groups for connected apps and dependencies.